### PR TITLE
fix average true range

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following list of indicators are currently supported by this package:
 ### Volatility Indicators
 
 - [Acceleration Bands](volatility_indicators.md#acceleration-bands)
-- [Actual True Range (ATR)](volatility_indicators.md#actual-true-range-atr)
+- [Average True Range (ATR)](volatility_indicators.md#average-true-range-atr)
 - [Bollinger Band Width](volatility_indicators.md#bollinger-band-width)
 - [Bollinger Bands](volatility_indicators.md#bollinger-bands)
 - [Chandelier Exit](volatility_indicators.md#chandelier-exit)

--- a/volatility_indicators.go
+++ b/volatility_indicators.go
@@ -32,7 +32,7 @@ func AccelerationBands(high, low, closing []float64) ([]float64, []float64, []fl
 // Average True Range (ATR). It is a technical analysis indicator that measures market
 // volatility by decomposing the entire range of stock prices for that period.
 //
-// TR = Max((High - Low), (High - Closing), (Closing - Low))
+// TR = Max((High - Low), Abs(High - Previous Closing), Abs(Low - Previous Closing))
 // ATR = SMA TR
 //
 // Returns tr, atr
@@ -42,7 +42,10 @@ func Atr(period int, high, low, closing []float64) ([]float64, []float64) {
 	tr := make([]float64, len(closing))
 
 	for i := 0; i < len(tr); i++ {
-		tr[i] = math.Max(high[i]-low[i], math.Max(high[i]-closing[i], closing[i]-low[i]))
+		if i == 0 {
+			continue
+		}
+		tr[i] = math.Max(high[i]-low[i], math.Max(math.Abs(high[i]-closing[i-1]), math.Abs(low[i]-closing[i-1])))
 	}
 
 	atr := Sma(period, tr)

--- a/volatility_indicators.md
+++ b/volatility_indicators.md
@@ -3,7 +3,7 @@
 Volatility indicators measure the rate of movement regardless of its direction.
 
 - [Acceleration Bands](#acceleration-bands)
-- [Actual True Range (ATR)](#actual-true-range-atr)
+- [Average True Range (ATR)](#average-true-range-atr)
 - [Bollinger Band Width](#bollinger-band-width)
 - [Bollinger Bands](#bollinger-bands)
 - [Chandelier Exit](#chandelier-exit)
@@ -27,12 +27,12 @@ Lower Band = SMA(Low * (1 + 4 * (High - Low) / (High + Low)))
 upperBand, middleBand, lowerBand := indicator.AccelerationBands(high, low, closing)
 ```
 
-#### Actual True Range (ATR)
+#### Average True Range (ATR)
 
 The [Atr](https://pkg.go.dev/github.com/cinar/indicator#Atr) function calculates a technical analysis indicator that measures market volatility by decomposing the entire range of stock prices for that period.
 
 ```
-TR = Max((High - Low), (High - Closing), (Closing - Low))
+TR = Max((High - Low), Abs(High - Previous Closing), Abs(Low - Previous Closing))
 ATR = 14-Period SMA TR
 ```
 


### PR DESCRIPTION
This library calculates Average True Range incorrectly. True range is calculated using the previous close price and we need to take the absolute value of the diffs as well. Also fixing the readme typos. See this [reference](https://www.investopedia.com/terms/a/atr.asp) to verify I'm calculating it correctly.